### PR TITLE
feat(material): add generic UE material graph conversion for Blender

### DIFF
--- a/FortnitePorting.Exporting/Context/ExportContext.Material.cs
+++ b/FortnitePorting.Exporting/Context/ExportContext.Material.cs
@@ -48,6 +48,9 @@ public partial class ExportContext
 
         AccumulateParameters(exportMat, ref exportMaterial);
 
+        if (Meta.Settings.ExportMaterialGraph && exportMaterial.BaseMaterial is { } baseMaterial)
+            exportMaterial.Graph = MaterialGraph(baseMaterial);
+
         exportMaterial.OverrideBlendMode = (exportMat as UMaterialInstanceConstant)?.BasePropertyOverrides?.BlendMode ?? exportMaterial.BaseBlendMode;
 
         MaterialCache.Add(exportMaterial);

--- a/FortnitePorting.Exporting/Context/ExportContext.MaterialGraph.cs
+++ b/FortnitePorting.Exporting/Context/ExportContext.MaterialGraph.cs
@@ -1,0 +1,305 @@
+using System.Collections.Generic;
+using System.Linq;
+using CUE4Parse.UE4.Assets.Exports.Material;
+using CUE4Parse.UE4.Assets.Exports.Material.Editor;
+using CUE4Parse.UE4.Assets.Exports.Texture;
+using CUE4Parse.UE4.Assets.Objects;
+using CUE4Parse.UE4.Assets.Objects.Properties;
+using CUE4Parse.UE4.Objects.Core.Math;
+using CUE4Parse.UE4.Objects.Engine;
+using CUE4Parse.UE4.Objects.UObject;
+using CUE4Parse.Utils;
+using FortnitePorting.CUE4Parse.Extensions;
+using FortnitePorting.Exporting.Models;
+
+namespace FortnitePorting.Exporting.Context;
+
+// Generic, structural export of a material's Unreal expression graph, as a fallback/alternative
+// to the curated ParameterCollection template system for materials with no matching template.
+// Ported from FortnitePorting/Models/Nodes/Material/MaterialNodeTree.cs (in-app material preview
+// viewer), which already walks this graph generically via CUE4Parse's UObject/FProperty reflection.
+public partial class ExportContext
+{
+    private Dictionary<string, MaterialGraphNode> GraphNodeCache = [];
+
+    public MaterialGraph? MaterialGraph(UMaterial? material)
+    {
+        if (material is null) return null;
+        if (!material.TryLoadEditorData<UMaterialEditorOnlyData>(out var editorData) || editorData is null) return null;
+
+        GraphNodeCache = [];
+        var graph = new MaterialGraph();
+
+        var expressionCollection = editorData.GetOrDefault<FStructFallback>("ExpressionCollection");
+        if (expressionCollection is null) return graph;
+
+        var expressions = expressionCollection.GetOrDefault<FPackageIndex[]>("Expressions", []);
+        foreach (var expressionLazy in expressions)
+        {
+            if (expressionLazy.Load<UMaterialExpression>() is not { } expression) continue;
+            if (GraphNodeCache.ContainsKey(expression.Name)) continue;
+
+            AddGraphNode(expression, graph);
+        }
+
+        if (editorData.Properties.FirstOrDefault(prop => prop.Name.Text.Equals("MaterialAttributes")) is { } materialAttributesProperty)
+        {
+            AddGraphOutput(graph, "MaterialAttributes", materialAttributesProperty);
+        }
+        else
+        {
+            foreach (var property in editorData.Properties)
+            {
+                if (property.Name.Text.Equals("ExpressionCollection")) continue;
+                AddGraphOutput(graph, property.Name.Text, property);
+            }
+        }
+
+        return graph;
+    }
+
+    private void AddGraphOutput(MaterialGraph graph, string name, FPropertyTag property)
+    {
+        // Top-level material inputs (BaseColor, Metallic, etc.) are UStructs (FColorMaterialInput,
+        // FScalarMaterialInput, ...) rather than plain FExpressionInput, so read them generically
+        // as a struct fallback instead of MaterialNodeTree.cs's GetValue<FExpressionInput>() (which
+        // would silently drop the UseConstant/Constant fallback fields these structs also carry).
+        if (property.Tag is not StructProperty) return;
+        if (property.Tag.GetValue<FStructFallback>() is not { } structFallback) return;
+
+        MaterialGraphNode? sourceNode = null;
+        if (structFallback.GetOrDefault<FPackageIndex?>("Expression") is { } expressionIndex
+            && expressionIndex.Load<UMaterialExpression>() is { } sourceExpression)
+        {
+            sourceNode = GetOrAddGraphNode(sourceExpression, graph);
+        }
+
+        var useConstant = structFallback.GetOrDefault("UseConstant", false);
+        if (sourceNode is null && !useConstant) return;
+
+        graph.Outputs.Add(new MaterialGraphOutput
+        {
+            PropertyName = name,
+            SourceNodeId = sourceNode?.Id,
+            SourceOutputIndex = structFallback.GetOrDefault("OutputIndex", 0),
+            DefaultValue = useConstant ? ReadConstantValue(structFallback, "Constant") : null
+        });
+    }
+
+    private MaterialGraphNode GetOrAddGraphNode(UMaterialExpression expression, MaterialGraph graph)
+    {
+        return GraphNodeCache.TryGetValue(expression.Name, out var existing) ? existing : AddGraphNode(expression, graph);
+    }
+
+    private MaterialGraphNode AddGraphNode(UMaterialExpression expression, MaterialGraph graph)
+    {
+        var node = new MaterialGraphNode
+        {
+            Id = expression.Name,
+            Type = expression.ExportType.SubstringAfter("MaterialExpression")
+        };
+
+        GraphNodeCache[node.Id] = node;
+        graph.Nodes.Add(node);
+
+        SetupGraphNodeContent(node, expression, graph);
+
+        foreach (var property in expression.Properties)
+        {
+            if (property.Tag is not StructProperty) continue;
+            if (property.Tag.GetValue<FExpressionInput>() is not { } expressionInput) continue;
+
+            var name = property.Name.Text;
+            AddGraphInput(node, graph, expression, expressionInput, name.Equals("Input") ? string.Empty : name);
+        }
+
+        if (node.Outputs.Count == 0) node.Outputs.Add(string.Empty);
+
+        return node;
+    }
+
+    private void AddGraphInput(MaterialGraphNode node, MaterialGraph graph, UMaterialExpression expression, FExpressionInput expressionInput, string name)
+    {
+        var input = new MaterialGraphInput
+        {
+            Name = name,
+            Mask = expressionInput.Mask,
+            MaskR = expressionInput.MaskR,
+            MaskG = expressionInput.MaskG,
+            MaskB = expressionInput.MaskB,
+            MaskA = expressionInput.MaskA
+        };
+
+        if (expressionInput.Expression?.Load<UMaterialExpression>() is { } sourceExpression)
+        {
+            var sourceNode = GetOrAddGraphNode(sourceExpression, graph);
+            input.SourceNodeId = sourceNode.Id;
+            input.SourceOutputIndex = expressionInput.OutputIndex;
+        }
+        else if (!string.IsNullOrEmpty(name))
+        {
+            input.DefaultValue = ReadInputConstantFallback(expression, name);
+        }
+
+        node.Inputs.Add(input);
+    }
+
+    // Many math expressions (Add, Multiply, Lerp, ...) expose a "ConstX" (or "XDefault") sibling
+    // scalar/color property used by Unreal when input pin X is left unconnected. Best-effort lookup
+    // across the naming conventions observed in Unreal's material expression classes.
+    private static object? ReadInputConstantFallback(UMaterialExpression expression, string inputName)
+    {
+        foreach (var candidate in new[] { $"Const{inputName}", $"{inputName}Default", $"Default{inputName}" })
+        {
+            if (!expression.Properties.Any(p => p.Name.Text.Equals(candidate))) continue;
+
+            if (expression.TryGetValue(out float floatValue, candidate)) return floatValue;
+            if (expression.TryGetValue(out FLinearColor colorValue, candidate)) return ToColorArray(colorValue);
+        }
+
+        return null;
+    }
+
+    private static object? ReadConstantValue(FStructFallback structFallback, string name)
+    {
+        if (structFallback.TryGetValue(out FLinearColor colorConstant, name)) return ToColorArray(colorConstant);
+        if (structFallback.TryGetValue(out float floatConstant, name)) return floatConstant;
+
+        return null;
+    }
+
+    private static float[] ToColorArray(FLinearColor color) => [color.R, color.G, color.B, color.A];
+
+    private static void AddColorOutputs(MaterialGraphNode node, bool includeRGBA = false)
+    {
+        node.Outputs.AddRange(["RGB", "R", "G", "B", "A"]);
+        if (includeRGBA) node.Outputs.Add("RGBA");
+    }
+
+    private void SetupGraphNodeContent(MaterialGraphNode node, UMaterialExpression expression, MaterialGraph graph)
+    {
+        switch (expression.ExportType)
+        {
+            case "MaterialExpressionTextureSampleParameter2D":
+            case "MaterialExpressionTextureSample":
+            case "MaterialExpressionTextureObjectParameter":
+            {
+                AddColorOutputs(node, includeRGBA: true);
+
+                if (expression.GetOrDefault<FName?>("ParameterName") is { IsNone: false } parameterName)
+                    node.Properties["ParameterName"] = parameterName.Text;
+
+                if (expression.GetOrDefault<UTexture>("Texture") is { } texture)
+                    node.Properties["Texture"] = new ExportTexture(Export(texture), texture.SRGB, texture.CompressionSettings);
+
+                break;
+            }
+            case "MaterialExpressionConstant":
+            {
+                node.Properties["R"] = expression.GetOrDefault<float>("R");
+                break;
+            }
+            case "MaterialExpressionConstant2Vector":
+            {
+                AddColorOutputs(node);
+                node.Properties["R"] = expression.GetOrDefault<float>("R");
+                node.Properties["G"] = expression.GetOrDefault<float>("G");
+                break;
+            }
+            case "MaterialExpressionConstant3Vector":
+            case "MaterialExpressionConstant4Vector":
+            case "MaterialExpressionVectorParameter":
+            {
+                AddColorOutputs(node);
+
+                var constantColor = expression.GetOrDefault<FLinearColor>(expression.ExportType == "MaterialExpressionVectorParameter" ? "DefaultValue" : "Constant");
+                if (expression.ExportType == "MaterialExpressionConstant3Vector") constantColor.A = 1;
+
+                node.Properties["R"] = constantColor.R;
+                node.Properties["G"] = constantColor.G;
+                node.Properties["B"] = constantColor.B;
+                node.Properties["A"] = constantColor.A;
+
+                if (expression.ExportType == "MaterialExpressionVectorParameter" && expression.GetOrDefault<FName?>("ParameterName") is { IsNone: false } vectorParamName)
+                    node.Properties["ParameterName"] = vectorParamName.Text;
+
+                break;
+            }
+            case "MaterialExpressionParticleColor":
+            case "MaterialExpressionVertexColor":
+            {
+                AddColorOutputs(node);
+                break;
+            }
+            case "MaterialExpressionScalarParameter":
+            {
+                node.Properties["DefaultValue"] = expression.GetOrDefault<float>("DefaultValue");
+                if (expression.GetOrDefault<FName?>("ParameterName") is { IsNone: false } scalarParamName)
+                    node.Properties["ParameterName"] = scalarParamName.Text;
+                break;
+            }
+            case "MaterialExpressionStaticBoolParameter":
+            {
+                node.Properties["DefaultValue"] = expression.GetOrDefault<bool>("DefaultValue");
+                if (expression.GetOrDefault<FName?>("ParameterName") is { IsNone: false } boolParamName)
+                    node.Properties["ParameterName"] = boolParamName.Text;
+                break;
+            }
+            case "MaterialExpressionComponentMask":
+            {
+                node.Properties["R"] = expression.GetOrDefault<bool>("R");
+                node.Properties["G"] = expression.GetOrDefault<bool>("G");
+                node.Properties["B"] = expression.GetOrDefault<bool>("B");
+                node.Properties["A"] = expression.GetOrDefault<bool>("A");
+                break;
+            }
+            case "MaterialExpressionTextureCoordinate":
+            {
+                node.Properties["CoordinateIndex"] = expression.GetOrDefault<int>("CoordinateIndex");
+                node.Properties["UTiling"] = expression.GetOrDefault<float>("UTiling", 1f);
+                node.Properties["VTiling"] = expression.GetOrDefault<float>("VTiling", 1f);
+                break;
+            }
+            case "MaterialExpressionPanner":
+            {
+                node.Properties["SpeedX"] = expression.GetOrDefault<float>("SpeedX");
+                node.Properties["SpeedY"] = expression.GetOrDefault<float>("SpeedY");
+                break;
+            }
+            case "MaterialExpressionFresnel":
+            {
+                node.Properties["Exponent"] = expression.GetOrDefault<float>("Exponent", 5f);
+                node.Properties["BaseReflectFraction"] = expression.GetOrDefault<float>("BaseReflectFraction", 0.04f);
+                break;
+            }
+            case "MaterialExpressionPower":
+            {
+                node.Properties["ConstExponent"] = expression.GetOrDefault<float>("ConstExponent", 2f);
+                break;
+            }
+            case "MaterialExpressionNamedRerouteDeclaration":
+            {
+                node.Type = "Reroute";
+                break;
+            }
+            case "MaterialExpressionNamedRerouteUsage":
+            {
+                node.Type = "Reroute";
+
+                if (expression.GetOrDefault<FPackageIndex?>("Declaration") is { } declarationIndex
+                    && declarationIndex.Load<UMaterialExpression>() is { } declarationExpression)
+                {
+                    var declarationNode = GetOrAddGraphNode(declarationExpression, graph);
+                    node.Inputs.Add(new MaterialGraphInput
+                    {
+                        Name = string.Empty,
+                        SourceNodeId = declarationNode.Id,
+                        SourceOutputIndex = 0
+                    });
+                }
+
+                break;
+            }
+        }
+    }
+}

--- a/FortnitePorting.Exporting/Models/ExportMaterial.cs
+++ b/FortnitePorting.Exporting/Models/ExportMaterial.cs
@@ -29,6 +29,8 @@ public record ExportMaterial : ParameterCollection
     public ETranslucencyLightingMode TranslucencyLightingMode => BaseMaterial?.TranslucencyLightingMode ?? ETranslucencyLightingMode.TLM_VolumetricDirectional;
     public EMaterialShadingModel ShadingModel => BaseMaterial?.ShadingModel ?? EMaterialShadingModel.MSM_DefaultLit;
 
+    public MaterialGraph? Graph;
+
     [JsonIgnore] public UMaterial? BaseMaterial;
 }
 

--- a/FortnitePorting.Exporting/Models/ExportSettings.cs
+++ b/FortnitePorting.Exporting/Models/ExportSettings.cs
@@ -11,6 +11,7 @@ public class ExportSettings
     public EFileCompressionFormat CompressionFormat { get; set; } = EFileCompressionFormat.ZSTD;
     public EImageFormat ImageFormat { get; set; } = EImageFormat.PNG;
     public bool ExportMaterials { get; set; } = true;
+    public bool ExportMaterialGraph { get; set; } = false;
     public EMeshFormat MeshFormat { get; set; } = EMeshFormat.UEFormat;
     public bool ExportNanite { get; set; } = false;
     public bool ImportInstancedFoliage { get; set; } = true;

--- a/FortnitePorting.Exporting/Models/MaterialGraph.cs
+++ b/FortnitePorting.Exporting/Models/MaterialGraph.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+
+namespace FortnitePorting.Exporting.Models;
+
+public record MaterialGraph
+{
+    public List<MaterialGraphNode> Nodes = [];
+    public List<MaterialGraphOutput> Outputs = [];
+}
+
+public record MaterialGraphNode
+{
+    public string Id = string.Empty;
+    public string Type = string.Empty;
+    public Dictionary<string, object?> Properties = [];
+    public List<MaterialGraphInput> Inputs = [];
+    public List<string> Outputs = [];
+}
+
+public record MaterialGraphInput
+{
+    public string Name = string.Empty;
+    public string? SourceNodeId;
+    public int SourceOutputIndex;
+    public object? DefaultValue;
+
+    // Inline component-mask carried directly on the connection (UE lets any wire swizzle without a dedicated node)
+    public int Mask;
+    public int MaskR;
+    public int MaskG;
+    public int MaskB;
+    public int MaskA;
+}
+
+public record MaterialGraphOutput
+{
+    public string PropertyName = string.Empty;
+    public string? SourceNodeId;
+    public int SourceOutputIndex;
+    public object? DefaultValue;
+}

--- a/FortnitePorting.Plugins/Blender/fortnite_porting/processing/context/material_context.py
+++ b/FortnitePorting.Plugins/Blender/fortnite_porting/processing/context/material_context.py
@@ -481,44 +481,55 @@ class MaterialImportContext:
 
         all_mappings = find_all_matching_mappings(material_data)
 
-        set_param("AO", self.options.get("AmbientOcclusion"))
-        set_param("Cavity", self.options.get("Cavity"))
-        set_param("Subsurface Scale", self.options.get("Subsurface"))
+        # Accurate Material Conversion: rebuild the actual Unreal expression graph instead of
+        # matching it against the curated MappingCollection templates. Used when the user forces
+        # it on, or automatically as a fallback when no template recognizes this material at all.
+        graph_data = material_data.get("Graph")
+        use_material_graph = bool(graph_data) and (self.options.get("ExportMaterialGraph") or len(all_mappings) == 0)
 
-        node_position = -200
-        previous_node = shader_node
+        if use_material_graph:
+            nodes.remove(shader_node)
+            from ..material.graph import build as build_material_graph
+            build_material_graph(self, nodes, links, graph_data, output_node.inputs[0])
+        else:
+            set_param("AO", self.options.get("AmbientOcclusion"))
+            set_param("Cavity", self.options.get("Cavity"))
+            set_param("Subsurface Scale", self.options.get("Subsurface"))
 
-        if len(all_mappings) == 0 or all_mappings[-1].type != ENodeType.NT_Base:
-            all_mappings.append(DefaultMappings)
+            node_position = -200
+            previous_node = shader_node
 
-        def add_shader_module(mapping):
-            nonlocal node_position, previous_node
-            new_node = nodes.new(type="ShaderNodeGroup")
-            new_node.node_tree = bpy.data.node_groups.get(mapping.node_name)
-            new_node.location = (node_position, 0)
-            links.new(new_node.outputs[0], previous_node.inputs[0])
-            setup_params(mapping, new_node)
-            previous_node = new_node
-            node_position -= mapping.node_spacing
-            return new_node
+            if len(all_mappings) == 0 or all_mappings[-1].type != ENodeType.NT_Base:
+                all_mappings.append(DefaultMappings)
 
-        for mapping in all_mappings:
-            add_shader_module(mapping)
-            if mapping.surface_render_method is not None:
-                material.surface_render_method = mapping.surface_render_method
-                material.show_transparent_back = mapping.show_transparent_back
+            def add_shader_module(mapping):
+                nonlocal node_position, previous_node
+                new_node = nodes.new(type="ShaderNodeGroup")
+                new_node.node_tree = bpy.data.node_groups.get(mapping.node_name)
+                new_node.location = (node_position, 0)
+                links.new(new_node.outputs[0], previous_node.inputs[0])
+                setup_params(mapping, new_node)
+                previous_node = new_node
+                node_position -= mapping.node_spacing
+                return new_node
 
-        # TODO: MappingCollection.material_changes()?
-        # That wouldn't give us the toon outline though because we couldn't call self.add_toon_outline
-        if all_mappings[-1].node_name == "FPv4 Base Toon":
-            set_param("Brightness", self.options.get("ToonShadingBrightness"), previous_node)
-            self.add_toon_outline = True
+            for mapping in all_mappings:
+                add_shader_module(mapping)
+                if mapping.surface_render_method is not None:
+                    material.surface_render_method = mapping.surface_render_method
+                    material.show_transparent_back = mapping.show_transparent_back
 
-        # TODO: Part modifier handling? (fur, new toon outline, etc)
-        
-        add_unused_params()
+            # TODO: MappingCollection.material_changes()?
+            # That wouldn't give us the toon outline though because we couldn't call self.add_toon_outline
+            if all_mappings[-1].node_name == "FPv4 Base Toon":
+                set_param("Brightness", self.options.get("ToonShadingBrightness"), previous_node)
+                self.add_toon_outline = True
 
-        links.new(shader_node.outputs[0], output_node.inputs[0])
+            # TODO: Part modifier handling? (fur, new toon outline, etc)
+
+            add_unused_params()
+
+            links.new(shader_node.outputs[0], output_node.inputs[0])
 
         # post parameter handling
 

--- a/FortnitePorting.Plugins/Blender/fortnite_porting/processing/material/graph/__init__.py
+++ b/FortnitePorting.Plugins/Blender/fortnite_porting/processing/material/graph/__init__.py
@@ -1,0 +1,1 @@
+from .graph_builder import build

--- a/FortnitePorting.Plugins/Blender/fortnite_porting/processing/material/graph/graph_builder.py
+++ b/FortnitePorting.Plugins/Blender/fortnite_porting/processing/material/graph/graph_builder.py
@@ -1,0 +1,186 @@
+from .node_builders import UE_NODE_BUILDERS, build_unsupported
+
+# Maps UE top-level material output property names to Blender Principled BSDF input socket
+# names. Blender 4.2+ socket names (addon targets blender_version_min = "4.2.0" per
+# blender_manifest.toml, so no legacy Blender socket-name branching needed).
+PRINCIPLED_OUTPUT_MAP = {
+    "BaseColor": "Base Color",
+    "Metallic": "Metallic",
+    "Roughness": "Roughness",
+    "EmissiveColor": "Emission Color",
+    "Opacity": "Alpha",
+    "OpacityMask": "Alpha",
+    "Specular": "Specular IOR Level",
+}
+
+NORMAL_OUTPUT_NAME = "Normal"
+
+
+def build(ctx, nodes, links, graph_data, output_socket):
+    """Builds a Blender node graph equivalent to the exported UE material expression graph
+    and wires it into `output_socket` (a Material Output node's Surface input). Nodes not
+    reachable from any top-level output are never built. Returns True if anything was wired."""
+
+    if not graph_data or not graph_data.get("Nodes"):
+        return False
+
+    node_lookup = {node_data["Id"]: node_data for node_data in graph_data["Nodes"]}
+    built_cache = {}
+    in_progress = set()
+
+    def get_built(node_id):
+        if node_id in built_cache:
+            return built_cache[node_id]
+        if node_id in in_progress:
+            return None  # defensive cycle guard; UE material graphs should be acyclic
+
+        node_data = node_lookup.get(node_id)
+        if node_data is None:
+            return None
+
+        in_progress.add(node_id)
+        builder = UE_NODE_BUILDERS.get(node_data.get("Type"), build_unsupported)
+        built = builder(ctx, nodes, node_data)
+        built_cache[node_id] = built
+        in_progress.discard(node_id)
+
+        for from_socket, to_socket in built.extra_links:
+            links.new(from_socket, to_socket)
+
+        for node_input in node_data.get("Inputs", []):
+            wire_input(built, node_input)
+
+        return built
+
+    def resolve_source(connection):
+        source_id = connection.get("SourceNodeId")
+        if source_id is None:
+            return None
+
+        source_built = get_built(source_id)
+        if source_built is None:
+            return None
+
+        index = connection.get("SourceOutputIndex", 0)
+        return source_built.outputs.get(index, source_built.outputs.get(0))
+
+    def apply_mask(source_socket, connection):
+        if not connection.get("Mask") or getattr(source_socket, "type", None) != "RGBA":
+            return source_socket
+
+        selected = [name for name, key in (("Red", "MaskR"), ("Green", "MaskG"), ("Blue", "MaskB")) if connection.get(key)]
+        if len(selected) != 1:
+            return source_socket
+
+        separate = nodes.new(type="ShaderNodeSeparateColor")
+        separate.mode = "RGB"
+        separate.hide = True
+        links.new(source_socket, separate.inputs["Color"])
+        return separate.outputs[selected[0]]
+
+    def wire_input(built, node_input):
+        consumer = built.inputs.get(node_input.get("Name", ""))
+        if consumer is None:
+            return
+
+        source_socket = resolve_source(node_input)
+        if source_socket is None:
+            default_value = node_input.get("DefaultValue")
+            if default_value is not None:
+                apply_default_value(consumer, default_value)
+            return
+
+        links.new(apply_mask(source_socket, node_input), consumer)
+
+    principled = nodes.new(type="ShaderNodeBsdfPrincipled")
+    links.new(principled.outputs["BSDF"], output_socket)
+
+    wired_any = False
+    for graph_output in graph_data.get("Outputs", []):
+        property_name = graph_output.get("PropertyName")
+        is_normal = property_name == NORMAL_OUTPUT_NAME
+        socket_name = PRINCIPLED_OUTPUT_MAP.get(property_name)
+
+        if socket_name is None and not is_normal:
+            continue  # no Principled-compatible slot this phase (WorldPositionOffset, Refraction, ...)
+
+        source_socket = resolve_source(graph_output)
+        if source_socket is None:
+            default_value = graph_output.get("DefaultValue")
+            if default_value is not None and not is_normal:
+                apply_default_value(principled.inputs[socket_name], default_value)
+                wired_any = True
+            continue
+
+        source_socket = apply_mask(source_socket, graph_output)
+
+        if is_normal:
+            normal_map = nodes.new(type="ShaderNodeNormalMap")
+            links.new(source_socket, normal_map.inputs["Color"])
+            links.new(normal_map.outputs["Normal"], principled.inputs["Normal"])
+        else:
+            links.new(source_socket, principled.inputs[socket_name])
+            if property_name == "EmissiveColor":
+                principled.inputs["Emission Strength"].default_value = 1.0
+
+        wired_any = True
+
+    layout_nodes(node_lookup, built_cache, graph_data, principled)
+
+    return wired_any
+
+
+def apply_default_value(socket, value):
+    try:
+        if isinstance(value, (list, tuple)):
+            if hasattr(socket.default_value, "__len__"):
+                target_length = len(socket.default_value)
+                if target_length == 4:
+                    socket.default_value = (value[0], value[1], value[2], value[3] if len(value) > 3 else 1.0)
+                elif target_length == 3:
+                    socket.default_value = tuple(value[:3])
+        else:
+            socket.default_value = value
+    except (TypeError, ValueError):
+        pass  # socket type didn't accept the literal; leave its own default
+
+
+def layout_nodes(node_lookup, built_cache, graph_data, principled):
+    """Places built nodes in columns by longest distance from the material outputs, so the
+    graph reads left-to-right upstream. Not pixel-parity with Unreal's own layout."""
+    spacing_x = 260
+    spacing_y = 220
+
+    depths = {}
+    visiting = set()
+
+    def compute_depth(node_id, depth):
+        if node_id not in built_cache or node_id in visiting:
+            return
+        if depths.get(node_id, -1) >= depth:
+            return
+
+        depths[node_id] = depth
+        visiting.add(node_id)
+
+        for node_input in node_lookup.get(node_id, {}).get("Inputs", []):
+            source_id = node_input.get("SourceNodeId")
+            if source_id:
+                compute_depth(source_id, depth + 1)
+
+        visiting.discard(node_id)
+
+    for graph_output in graph_data.get("Outputs", []):
+        source_id = graph_output.get("SourceNodeId")
+        if source_id:
+            compute_depth(source_id, 1)
+
+    columns = {}
+    for node_id, depth in depths.items():
+        columns.setdefault(depth, []).append(node_id)
+
+    principled.location = (0, 0)
+    for depth, node_ids in columns.items():
+        x = -depth * spacing_x
+        for row, node_id in enumerate(node_ids):
+            built_cache[node_id].node.location = (x, -row * spacing_y)

--- a/FortnitePorting.Plugins/Blender/fortnite_porting/processing/material/graph/node_builders.py
+++ b/FortnitePorting.Plugins/Blender/fortnite_porting/processing/material/graph/node_builders.py
@@ -1,0 +1,250 @@
+from ..context.material_context import create_texture_node, create_scalar_node, create_color_node
+
+UNSUPPORTED_COLOR = (1.0, 0.0, 1.0, 1.0)
+
+
+class BuiltNode:
+    """Wraps whatever bpy node(s) a single UE expression became, exposing its pins
+    in the same terms the exported graph uses: outputs keyed by UE output index,
+    inputs keyed by UE input pin name. `extra_links` are internal links between the
+    node(s) this builder created (e.g. Clamp's Max feeding into Min) that graph_builder
+    should wire up alongside the graph's own connections."""
+
+    def __init__(self, node, outputs=None, inputs=None, extra_links=None):
+        self.node = node
+        self.outputs = outputs if outputs is not None else ({0: node.outputs[0]} if node.outputs else {})
+        self.inputs = inputs if inputs is not None else {}
+        self.extra_links = extra_links or []
+
+
+def _color_outputs(nodes, node, include_rgba=False):
+    # Mirrors ExportContext.MaterialGraph.cs's AddColorOutputs ordering: RGB, R, G, B, A, (RGBA).
+    # Blender's RGB/TexImage nodes only expose a combined "Color" (+ "Alpha" for TexImage) socket,
+    # not separate R/G/B ones, so synthesize those via a SeparateColor node fed from Color.
+    color_socket = node.outputs["Color"]
+
+    separate = nodes.new(type="ShaderNodeSeparateColor")
+    separate.mode = "RGB"
+    separate.hide = True
+
+    outputs = {0: color_socket, 1: separate.outputs["Red"], 2: separate.outputs["Green"], 3: separate.outputs["Blue"]}
+    extra_links = [(color_socket, separate.inputs["Color"])]
+
+    if "Alpha" in node.outputs:
+        outputs[4] = node.outputs["Alpha"]
+        if include_rgba:
+            outputs[5] = color_socket
+
+    return outputs, extra_links
+
+
+def build_texture_sample(ctx, nodes, node_data):
+    properties = node_data.get("Properties", {})
+    texture = properties.get("Texture")
+    label = properties.get("ParameterName") or node_data.get("Id")
+
+    if texture is None:
+        return build_unsupported(ctx, nodes, node_data)
+
+    image = ctx.import_image(texture.get("Path"))
+    node = create_texture_node(nodes, label, image, texture.get("sRGB"))
+    outputs, extra_links = _color_outputs(nodes, node, include_rgba=True)
+
+    return BuiltNode(node, outputs=outputs, inputs={"Coordinates": node.inputs[0]}, extra_links=extra_links)
+
+
+def build_texture_coordinate(ctx, nodes, node_data):
+    properties = node_data.get("Properties", {})
+    uv_node = nodes.new(type="ShaderNodeUVMap")
+
+    u_tiling = properties.get("UTiling", 1.0)
+    v_tiling = properties.get("VTiling", 1.0)
+    if u_tiling == 1.0 and v_tiling == 1.0:
+        return BuiltNode(uv_node)
+
+    mapping = nodes.new(type="ShaderNodeMapping")
+    mapping.inputs["Scale"].default_value = (u_tiling, v_tiling, 1.0)
+    return BuiltNode(mapping, outputs={0: mapping.outputs[0]}, extra_links=[(uv_node.outputs[0], mapping.inputs["Vector"])])
+
+
+def build_constant(ctx, nodes, node_data):
+    value = node_data.get("Properties", {}).get("R", 0.0)
+    node = create_scalar_node(nodes, node_data.get("Id"), value)
+    return BuiltNode(node)
+
+
+def build_constant2vector(ctx, nodes, node_data):
+    properties = node_data.get("Properties", {})
+    value = {"R": properties.get("R", 0.0), "G": properties.get("G", 0.0), "B": 0.0, "A": 1.0}
+    node = create_color_node(nodes, node_data.get("Id"), value)
+    outputs, extra_links = _color_outputs(nodes, node)
+    return BuiltNode(node, outputs=outputs, extra_links=extra_links)
+
+
+def build_color_constant(ctx, nodes, node_data):
+    properties = node_data.get("Properties", {})
+    label = properties.get("ParameterName") or node_data.get("Id")
+    value = {
+        "R": properties.get("R", 0.0),
+        "G": properties.get("G", 0.0),
+        "B": properties.get("B", 0.0),
+        "A": properties.get("A", 1.0),
+    }
+    node = create_color_node(nodes, label, value)
+    outputs, extra_links = _color_outputs(nodes, node)
+    return BuiltNode(node, outputs=outputs, extra_links=extra_links)
+
+
+def build_scalar_parameter(ctx, nodes, node_data):
+    properties = node_data.get("Properties", {})
+    label = properties.get("ParameterName") or node_data.get("Id")
+    node = create_scalar_node(nodes, label, properties.get("DefaultValue", 0.0))
+    return BuiltNode(node)
+
+
+def build_static_bool_parameter(ctx, nodes, node_data):
+    properties = node_data.get("Properties", {})
+    label = properties.get("ParameterName") or node_data.get("Id")
+    node = create_scalar_node(nodes, label, 1.0 if properties.get("DefaultValue") else 0.0)
+    return BuiltNode(node)
+
+
+def build_vertex_color(ctx, nodes, node_data):
+    node = nodes.new(type="ShaderNodeVertexColor")
+    outputs, extra_links = _color_outputs(nodes, node)
+    return BuiltNode(node, outputs=outputs, extra_links=extra_links)
+
+
+def build_component_mask(ctx, nodes, node_data):
+    properties = node_data.get("Properties", {})
+    separate = nodes.new(type="ShaderNodeSeparateColor")
+    separate.mode = "RGB"
+
+    selected = [channel for channel in ("R", "G", "B") if properties.get(channel)]
+    socket_name = {"R": "Red", "G": "Green", "B": "Blue"}
+
+    if len(selected) <= 1:
+        channel = selected[0] if selected else "R"
+        return BuiltNode(separate, outputs={0: separate.outputs[socket_name[channel]]}, inputs={"": separate.inputs["Color"]})
+
+    combine = nodes.new(type="ShaderNodeCombineColor")
+    combine.mode = "RGB"
+    extra_links = [(separate.outputs[socket_name[channel]], combine.inputs[socket_name[channel]]) for channel in selected]
+    return BuiltNode(combine, outputs={0: combine.outputs["Color"]}, inputs={"": separate.inputs["Color"]}, extra_links=extra_links)
+
+
+def build_math(operation, input_names=("A", "B")):
+    def _build(ctx, nodes, node_data):
+        node = nodes.new(type="ShaderNodeMath")
+        node.operation = operation
+        inputs = {name: node.inputs[index] for index, name in enumerate(input_names) if index < len(node.inputs)}
+        return BuiltNode(node, inputs=inputs)
+
+    return _build
+
+
+def build_one_minus(ctx, nodes, node_data):
+    node = nodes.new(type="ShaderNodeMath")
+    node.operation = "SUBTRACT"
+    node.inputs[0].default_value = 1.0
+    return BuiltNode(node, inputs={"": node.inputs[1]})
+
+
+def build_power(ctx, nodes, node_data):
+    node = nodes.new(type="ShaderNodeMath")
+    node.operation = "POWER"
+    node.inputs[1].default_value = node_data.get("Properties", {}).get("ConstExponent", 2.0)
+    return BuiltNode(node, inputs={"Base": node.inputs[0], "Exponent": node.inputs[1]})
+
+
+def build_clamp(ctx, nodes, node_data):
+    max_node = nodes.new(type="ShaderNodeMath")
+    max_node.operation = "MAXIMUM"
+    min_node = nodes.new(type="ShaderNodeMath")
+    min_node.operation = "MINIMUM"
+    min_node.location = max_node.location.x + 200, max_node.location.y
+
+    inputs = {"": max_node.inputs[0], "Min": max_node.inputs[1], "Max": min_node.inputs[1]}
+    return BuiltNode(min_node, inputs=inputs, extra_links=[(max_node.outputs[0], min_node.inputs[0])])
+
+
+def build_normalize(ctx, nodes, node_data):
+    node = nodes.new(type="ShaderNodeVectorMath")
+    node.operation = "NORMALIZE"
+    return BuiltNode(node, inputs={"VectorInput": node.inputs[0]})
+
+
+def build_lerp(ctx, nodes, node_data):
+    node = nodes.new(type="ShaderNodeMix")
+    node.data_type = "RGBA"
+    return BuiltNode(node, outputs={0: node.outputs["Result"]}, inputs={"A": node.inputs["A"], "B": node.inputs["B"], "Alpha": node.inputs["Factor"]})
+
+
+def build_dot_product(ctx, nodes, node_data):
+    node = nodes.new(type="ShaderNodeVectorMath")
+    node.operation = "DOT_PRODUCT"
+    return BuiltNode(node, outputs={0: node.outputs["Value"]}, inputs={"A": node.inputs[0], "B": node.inputs[1]})
+
+
+def build_append_vector(ctx, nodes, node_data):
+    node = nodes.new(type="ShaderNodeCombineXYZ")
+    return BuiltNode(node, inputs={"A": node.inputs["X"], "B": node.inputs["Y"]})
+
+
+def build_fresnel(ctx, nodes, node_data):
+    node = nodes.new(type="ShaderNodeFresnel")
+    return BuiltNode(node, inputs={"Normal": node.inputs["Normal"]})
+
+
+def build_panner(ctx, nodes, node_data):
+    properties = node_data.get("Properties", {})
+    node = nodes.new(type="ShaderNodeMapping")
+    node.inputs["Location"].default_value = (properties.get("SpeedX", 0.0), properties.get("SpeedY", 0.0), 0.0)
+    return BuiltNode(node, inputs={"Coordinate": node.inputs["Vector"]})
+
+
+def build_reroute(ctx, nodes, node_data):
+    node = nodes.new(type="NodeReroute")
+    return BuiltNode(node, inputs={"": node.inputs[0]})
+
+
+def build_unsupported(ctx, nodes, node_data):
+    node = nodes.new(type="ShaderNodeRGB")
+    node.outputs[0].default_value = UNSUPPORTED_COLOR
+    node.label = f"Unsupported: {node_data.get('Type')}"
+    return BuiltNode(node)
+
+
+UE_NODE_BUILDERS = {
+    "TextureSample": build_texture_sample,
+    "TextureSampleParameter2D": build_texture_sample,
+    "TextureObjectParameter": build_texture_sample,
+    "TextureCoordinate": build_texture_coordinate,
+    "Constant": build_constant,
+    "Constant2Vector": build_constant2vector,
+    "Constant3Vector": build_color_constant,
+    "Constant4Vector": build_color_constant,
+    "VectorParameter": build_color_constant,
+    "ScalarParameter": build_scalar_parameter,
+    "StaticBoolParameter": build_static_bool_parameter,
+    "VertexColor": build_vertex_color,
+    "ParticleColor": build_vertex_color,
+    "ComponentMask": build_component_mask,
+    "Add": build_math("ADD"),
+    "Subtract": build_math("SUBTRACT"),
+    "Multiply": build_math("MULTIPLY"),
+    "Divide": build_math("DIVIDE"),
+    "Abs": build_math("ABSOLUTE", input_names=("",)),
+    "Min": build_math("MINIMUM"),
+    "Max": build_math("MAXIMUM"),
+    "OneMinus": build_one_minus,
+    "Power": build_power,
+    "Clamp": build_clamp,
+    "LinearInterpolate": build_lerp,
+    "Normalize": build_normalize,
+    "DotProduct": build_dot_product,
+    "AppendVector": build_append_vector,
+    "Fresnel": build_fresnel,
+    "Panner": build_panner,
+    "Reroute": build_reroute,
+}

--- a/FortnitePorting/ViewModels/ExportSettingsViewModel.cs
+++ b/FortnitePorting/ViewModels/ExportSettingsViewModel.cs
@@ -56,6 +56,7 @@ public partial class BaseExportSettings : ViewModelBase
 
     [ObservableProperty] private EImageFormat _imageFormat = EImageFormat.PNG;
     [ObservableProperty] private bool _exportMaterials = true;
+    [ObservableProperty] private bool _exportMaterialGraph = false;
     
     [ObservableProperty] private EMeshFormat _meshFormat = EMeshFormat.UEFormat;
     [ObservableProperty] private bool _exportNanite;
@@ -82,6 +83,7 @@ public partial class BaseExportSettings : ViewModelBase
         CompressionFormat = CompressionFormat,
         ImageFormat = ImageFormat,
         ExportMaterials = ExportMaterials,
+        ExportMaterialGraph = ExportMaterialGraph,
         MeshFormat = MeshFormat,
         ExportNanite = ExportNanite,
         ImportInstancedFoliage = ImportInstancedFoliage,

--- a/FortnitePorting/Views/Settings/BlenderSettingsView.axaml
+++ b/FortnitePorting/Views/Settings/BlenderSettingsView.axaml
@@ -182,6 +182,13 @@
                                     <ToggleSwitch IsChecked="{Binding ExportMaterials}"/>
                                 </controls:SettingsItem.Footer>
                             </controls:SettingsItem>
+                            <controls:SettingsItem Title="Accurate Material Conversion"
+                                                   Description="Exports the actual Unreal material node graph and rebuilds an equivalent Blender node graph. Used automatically as a fallback for materials with no curated template; can be forced on for all materials. Slower and messier than the curated templates, but works on any material."
+                                                   IsEnabled="{Binding ExportMaterials}">
+                                <controls:SettingsItem.Footer>
+                                    <ToggleSwitch IsChecked="{Binding ExportMaterialGraph}"/>
+                                </controls:SettingsItem.Footer>
+                            </controls:SettingsItem>
                             <controls:SettingsItem Title="Ambient Occlusion"
                                                    Description="Adds darker details in the crevices of materials."
                                                    IsEnabled="{Binding ExportMaterials}">


### PR DESCRIPTION
Curated MappingCollection templates only cover known Fortnite shader families, leaving unrecognized materials with no conversion. Adds an opt-in "Accurate Material Conversion" path that exports the actual Unreal material expression graph and rebuilds an equivalent Blender node graph, used automatically as a fallback when no template matches.

Phase 1: covers the highest-coverage expression types (math ops, texture sampling, constants/parameters, component masking, Fresnel, Panner, named reroutes) with output wiring into a Principled BSDF. Unsupported node types render as a visible pink placeholder instead of silently dropping the connection. Material-function inlining, static switch baking, and composite/pin-base flattening are deferred.